### PR TITLE
workaround dune -fPIC issue

### DIFF
--- a/cuda_ffi/dune
+++ b/cuda_ffi/dune
@@ -9,6 +9,7 @@
   (external_library_name libcuda)
   (build_flags_resolver
    (vendored
+    (c_flags :standard -fPIC)
     (c_library_flags
      -lcuda
      -I

--- a/nvrtc_ffi/dune
+++ b/nvrtc_ffi/dune
@@ -9,6 +9,7 @@
   (external_library_name libnvrtc)
   (build_flags_resolver
    (vendored
+    (c_flags :standard -fPIC)
     (c_library_flags
      -lnvrtc
      -I


### PR DESCRIPTION
see https://github.com/ocaml/dune/issues/5809

I only saw the problem with ocaml 4, not ocaml 5 which ocannl requires anyway, so maybe something was fixed upstream, but technically someone could use this library independently with ocaml 4, idk if you want to merge this, just for posterity